### PR TITLE
error handling

### DIFF
--- a/api.js
+++ b/api.js
@@ -262,7 +262,7 @@ AirtouchAPI.prototype.decode_groups_status = function(data) {
 		});
 	}
 	this.emit("groups_status", groups_status);
-};		
+};
 
 // connect to Airtouch Touchpad Controller socket on tcp port 9004
 AirtouchAPI.prototype.connect = function(address) {
@@ -309,6 +309,19 @@ AirtouchAPI.prototype.connect = function(address) {
 				break;
 		}
 	});
+
+	// error handling to stop connection errors bringing down homebridge
+	this.device.on("error", function(err) {
+		this.log("API | Connection Error: " + err.message);
+		this.device.destroy(); //close the connection even though its already broken
+		setTimeout(() => {
+			if (!this.device.listening) { //only attempt reconnect if not already re-connected
+				this.log("API | Attempting reconnect");
+				this.emit("attempt_reconnect");
+			}
+		}, 10000);
+	}.bind(this));
+
 };
 
 module.exports = AirtouchAPI;

--- a/index.js
+++ b/index.js
@@ -64,6 +64,10 @@ function Airtouch(log, config, api) {
 	this.api.on("groups_status", (group_status) => {
 		this.onGroupsStatusNotification(group_status);
 	});
+	// will try to reconnect on api error - worried this might end up causing a loop..
+	this.api.on("attempt_reconnect", () => {
+		this.api.connect(config.ip_address);
+	});
 
 	// connect to the Airtouch Touchpad Controller
 	this.api.connect(config.ip_address);

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-airtouch4-platform",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Plugin for homebridge to connect to Airtouch4 AC controller",
   "main": "index.js",
   "keywords": [
     "homebridge-plugin",
-	"airtouch",
-	"air conditioner"
+    "airtouch",
+    "air conditioner"
   ],
   "author": "Marian Mihailescu <mihailescu2m@gmail.com>",
   "license": "ISC",
@@ -20,10 +20,13 @@
   },
   "dependencies": {
     "node-persist": "^2.1.0",
-	"fakegato-history": "^0.5.6"
+    "fakegato-history": "^0.5.6"
   },
   "bugs": {
     "url": "https://github.com/mihailescu2m/homebridge-airtouch4-platform/issues"
   },
-  "homepage": "https://github.com/mihailescu2m/homebridge-airtouch4-platform#readme"
+  "homepage": "https://github.com/mihailescu2m/homebridge-airtouch4-platform#readme",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
 }


### PR DESCRIPTION
Added error handling and reconnect to api connection.

This resolves an issue where the Airtouch tablet loses wifi, or the app is reset but homebridge stays running, which would result in an unhandled scoket error when the next command was sent.
Without this error handling, the error would cause my homebridge service to stop.