### PR TITLE
removed blank callback from identify function

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,6 @@ Airtouch.prototype.onGroupsStatusNotification = function(groups_status) {
 Airtouch.prototype.setupACAccessory = function(accessory) {
 	accessory.on('identify', (paired, cb) => {
 		this.log(accessory.displayName, " identified");
-		cb();
 	});
 
 	accessory.getService(Service.AccessoryInformation)
@@ -288,7 +287,6 @@ Airtouch.prototype.updateACAccessory = function(accessory, status) {
 Airtouch.prototype.setupZoneAccessory = function(accessory) {
 	accessory.on('identify', (paired, cb) => {
 		this.log(accessory.displayName, " identified");
-		cb();
 	});
 
 	accessory.getService(Service.AccessoryInformation)
@@ -432,7 +430,6 @@ Airtouch.prototype.updateZoneAccessory = function(accessory, status) {
 Airtouch.prototype.setupThermoAccessory = function(accessory) {
 	accessory.on('identify', (paired, cb) => {
 		this.log(accessory.displayName, " identified");
-		cb();
 	});
 
 	accessory.getService(Service.AccessoryInformation)


### PR DESCRIPTION
removed blank callbacks from the identify functions. Not entirely sure this works, but I was getting an error during startup (if my accessories changed):
`Error: This callback function has already been called by someone else; it can only be called one time.`

After removing the cb's I dont get the error and everything seems to work.